### PR TITLE
Better way of discovering common_versions.mk

### DIFF
--- a/build_device.sh
+++ b/build_device.sh
@@ -9,7 +9,8 @@ cd $BUILD_ROOT
 lunch $1
 
 TARGET_VENDOR=$(echo $TARGET_PRODUCT | cut -f1 -d '_')
-VER=$(cat vendor/$TARGET_VENDOR/configs/common_versions.mk | grep "TARGET_PRODUCT" | cut -f3 -d '_' | cut -f1 -d ' ')
+CV=$(find vendor/$TARGET_PRODUCT/ -name common_versions.mk)
+VER=$(cat $CV | grep "TARGET_PRODUCT" | cut -f3 -d '_' | cut -f1 -d ' ')
 ZIP=$(find $(echo $ANDROID_PRODUCT_OUT) -maxdepth 1 -name $(echo $TARGET_PRODUCT)_*-squished.zip)
 OUTD=$(echo $(cd ../upload && pwd))
 


### PR DESCRIPTION
It will search the vendor dir for common_versions, no matter where it's located for less user interaction.
